### PR TITLE
Simple debugger completion 

### DIFF
--- a/mos-core/src/codegen/mod.rs
+++ b/mos-core/src/codegen/mod.rs
@@ -485,10 +485,10 @@ impl CodegenContext {
                 if segment.emit(bytes) {
                     Ok(())
                 } else {
-                    return Err(Diagnostic::error()
+                    Err(Diagnostic::error()
                         .with_message(format!("segment '{}' is out of range", name))
                         .with_labels(vec![span.to_label()])
-                        .into());
+                        .into())
                 }
             }
             None => {
@@ -881,7 +881,7 @@ impl CodegenContext {
                                 + 2)
                             .as_i64();
                             let mut offset = target_pc - cur_pc;
-                            if offset >= -128 && offset <= 127 {
+                            if (-128..=127).contains(&offset) {
                                 if offset < 0 {
                                     offset += 256;
                                 }

--- a/mos-core/src/codegen/source_map.rs
+++ b/mos-core/src/codegen/source_map.rs
@@ -8,7 +8,7 @@ pub struct SourceMap {
     offsets: Vec<SourceMapOffset>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SourceMapOffset {
     pub scope: SymbolIndex,
     pub span: Span,

--- a/mos-core/src/codegen/symbols.rs
+++ b/mos-core/src/codegen/symbols.rs
@@ -18,7 +18,7 @@ pub struct SymbolTable<S: Clone + Debug> {
 pub type SymbolIndex = NodeIndex;
 pub type SymbolIndices<'a, S> = NodeIndices<'a, Item<S>>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum QueryTraversalStep {
     Symbol(SymbolIndex),
     Super(SymbolIndex),

--- a/mos-core/src/formatting/mod.rs
+++ b/mos-core/src/formatting/mod.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Casing {
     Uppercase,
@@ -25,7 +25,7 @@ impl Casing {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct MnemonicOptions {
     pub casing: Casing,
@@ -41,14 +41,14 @@ impl Default for MnemonicOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum BracePosition {
     SameLine,
     NewLine,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct BraceOptions {
     pub position: BracePosition,
@@ -62,7 +62,7 @@ impl Default for BraceOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct WhitespaceOptions {
     pub indent: usize,
@@ -71,7 +71,7 @@ pub struct WhitespaceOptions {
     pub code_margin: usize,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum Alignment {
     Left,
@@ -89,7 +89,7 @@ impl Default for WhitespaceOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ListingOptions {
     pub num_bytes_per_line: usize,
@@ -103,7 +103,7 @@ impl Default for ListingOptions {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct FormattingOptions {
     pub mnemonics: MnemonicOptions,

--- a/mos-core/src/parser/ast.rs
+++ b/mos-core/src/parser/ast.rs
@@ -155,7 +155,7 @@ pub enum Trivia {
 }
 
 /// Registers used for indexing
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IndexRegister {
     X,
     Y,
@@ -179,7 +179,7 @@ pub struct Instruction {
 }
 
 /// The addressing mode for the instruction
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AddressingMode {
     /// Absolute or Zero-Page addressing (e.g. `LDA $34`)
     AbsoluteOrZp,
@@ -211,7 +211,7 @@ pub struct RegisterSuffix {
 }
 
 /// A number, which can be hexadecimal (`$23AB`), decimal (`123`) or binary (`%11011`)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NumberType {
     Hex,
     Dec,
@@ -229,7 +229,7 @@ impl Display for NumberType {
 }
 
 /// An address modifier which can be used to get the low (`<`) or high (`>`) byte of an address
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AddressModifier {
     HighByte,
     LowByte,
@@ -245,7 +245,7 @@ impl Display for AddressModifier {
 }
 
 /// Any kind of binary operation that can be found in an expression
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinaryOp {
     /// Addition
     Add,
@@ -339,7 +339,7 @@ pub enum ExpressionFactor {
 }
 
 /// A wrapper that stores the original number string and its radix, so that any zero-prefixes are kept
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Number {
     radix: u32,
     data: String,
@@ -422,7 +422,7 @@ impl Expression {
 }
 
 /// User-defined variables
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum VariableType {
     Constant,
     Variable,
@@ -438,7 +438,7 @@ impl Display for VariableType {
 }
 
 /// The size of a data directive (e.g. `.byte 1, 2, 3`)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DataSize {
     Byte,
     Word,
@@ -475,7 +475,7 @@ impl Display for ImportAs {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TextEncoding {
     Ascii,
     Petscii,
@@ -854,19 +854,19 @@ pub fn format_trivia(trivia: &Option<Box<Located<Vec<Trivia>>>>) -> String {
         .unwrap_or_else(|| "".to_string())
 }
 
-impl<'a, T: Display> Display for Located<T> {
+impl<T: Display> Display for Located<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}{}", format_trivia(&self.trivia), &self.data)
     }
 }
 
-impl<'a, T: Display + LowerHex> LowerHex for Located<T> {
+impl<T: Display + LowerHex> LowerHex for Located<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}{:x}", format_trivia(&self.trivia), &self.data)
     }
 }
 
-impl<'a, T: Display + Binary> Binary for Located<T> {
+impl<T: Display + Binary> Binary for Located<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "{}{:b}", format_trivia(&self.trivia), &self.data)
     }

--- a/mos-core/src/parser/mnemonic.rs
+++ b/mos-core/src/parser/mnemonic.rs
@@ -4,7 +4,7 @@ use nom::bytes::complete::tag_no_case;
 use nom::combinator::map;
 
 /// The available 6502 instructions.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mnemonic {
     Adc,
     And,

--- a/mos/src/commands/build.rs
+++ b/mos/src/commands/build.rs
@@ -14,11 +14,11 @@ use std::path::{Path, PathBuf};
 use strum::EnumString;
 
 /// Assembles input file(s)
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "build")]
 pub struct BuildArgs {}
 
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct BuildOptions {
     pub entry: String,
@@ -72,14 +72,14 @@ impl Default for BuildOptions {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, EnumString)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, EnumString)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum OutputFormat {
     Prg,
     Bin,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, EnumString)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, EnumString)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum SymbolType {
     Vice,

--- a/mos/src/commands/format.rs
+++ b/mos/src/commands/format.rs
@@ -9,7 +9,7 @@ use mos_core::LINE_ENDING;
 use std::io::Write;
 
 /// Formats input file(s)
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "format")]
 pub struct FormatArgs {}
 

--- a/mos/src/commands/init.rs
+++ b/mos/src/commands/init.rs
@@ -6,7 +6,7 @@ use mos_core::errors::{map_io_error, Diagnostics};
 use std::path::Path;
 
 /// Creates a new MOS project configuration file
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "init")]
 pub struct InitArgs {}
 

--- a/mos/src/commands/lsp.rs
+++ b/mos/src/commands/lsp.rs
@@ -3,7 +3,7 @@ use crate::diagnostic_emitter::MosResult;
 use crate::lsp::{LspContext, LspServer};
 
 /// Starts a Language Server
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "lsp")]
 pub struct LspArgs {
     /// the port on which the debug adapter server should listen

--- a/mos/src/commands/test.rs
+++ b/mos/src/commands/test.rs
@@ -10,11 +10,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 /// Runs unit test(s)
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "test")]
 pub struct TestArgs {}
 
-#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct TestOptions {
     pub name: Option<String>,

--- a/mos/src/commands/version.rs
+++ b/mos/src/commands/version.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic_emitter::MosResult;
 
 /// Prints the version of the application
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand, name = "version")]
 pub struct VersionArgs {}
 

--- a/mos/src/config.rs
+++ b/mos/src/config.rs
@@ -3,7 +3,7 @@ use crate::diagnostic_emitter::MosResult;
 use mos_core::formatting::FormattingOptions;
 use serde::Deserialize;
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Config {
     pub build: BuildOptions,

--- a/mos/src/debugger/adapters/mod.rs
+++ b/mos/src/debugger/adapters/mod.rs
@@ -59,7 +59,7 @@ impl Machine {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MachineEvent {
     RunningStateChanged {
         old: MachineRunningState,
@@ -116,14 +116,14 @@ pub trait MachineAdapter: MemoryAccessor {
     fn flags(&self) -> MosResult<u8>;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MachineBreakpoint {
     pub line: usize,
     pub column: Option<usize>,
     pub range: Range<ProgramCounter>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MachineValidatedBreakpoint {
     pub id: usize,
     pub source_path: String,
@@ -131,7 +131,7 @@ pub struct MachineValidatedBreakpoint {
     pub range: Range<ProgramCounter>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MachineRunningState {
     Launching,
     Running,

--- a/mos/src/debugger/adapters/vice/protocol.rs
+++ b/mos/src/debugger/adapters/vice/protocol.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io;
 use std::io::{BufRead, Write};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ViceResponse {
     AdvanceInstructions,
     BanksAvailable(HashMap<u16, String>),
@@ -24,7 +24,7 @@ pub enum ViceResponse {
     Resumed(u16),
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct CheckpointResponse {
     pub number: u32,
     pub currently_hit: bool,
@@ -40,7 +40,7 @@ pub struct CheckpointResponse {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ViceRequest {
     AdvanceInstructions(bool, u16),
     BanksAvailable,
@@ -58,7 +58,7 @@ pub enum ViceRequest {
     Quit,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CheckpointSet {
     pub start: u16,
     pub end: u16,
@@ -68,7 +68,7 @@ pub struct CheckpointSet {
     pub temporary: bool,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MemoryDescriptor {
     pub cause_side_effects: bool,
     pub start: u16,

--- a/mos/src/debugger/mod.rs
+++ b/mos/src/debugger/mod.rs
@@ -578,12 +578,11 @@ impl CompletionsRequestHandler {
 }
 
 impl Handler<CompletionsRequest> for CompletionsRequestHandler {
-    // TODO: prettify the signature. Why is CompletionsResponse not allowed?
     fn handle(
         &self,
         conn: &mut DebugSession,
         args: <CompletionsRequest as Request>::Arguments,
-    ) -> MosResult<<CompletionsRequest as Request>::Response> {
+    ) -> MosResult<CompletionsResponse> {
         let registers = {
             let adapter = conn.machine_adapter()?;
             adapter.registers()?
@@ -600,8 +599,6 @@ impl Handler<CompletionsRequest> for CompletionsRequestHandler {
                 None => beginning,
             }
         };
-
-        println!("Completion string: {}", curr_completion);
 
         // get the completion candidates
         let candidates: Vec<String> = if curr_completion.starts_with("cpu.flags.") {
@@ -1059,9 +1056,6 @@ mod tests {
     #[test]
     fn completions() -> MosResult<()> {
         use mos_testing::assert_unordered_eq;
-
-        // TODO: completing in the middle of the word should probably not return the entire word?
-        //       or should it?
 
         let src = r#".test "a" {
                          ldx #123

--- a/mos/src/debugger/types.rs
+++ b/mos/src/debugger/types.rs
@@ -136,6 +136,8 @@ pub struct Capabilities {
     pub supports_value_formatting_options: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supports_set_variable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_completions_request: Option<bool>,
 }
 
 pub struct LaunchRequest {}
@@ -740,6 +742,36 @@ pub struct EvaluateResponse {
     pub indexed_variables: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_reference: Option<String>,
+}
+
+pub struct CompletionsRequest {}
+
+impl Request for CompletionsRequest {
+    type Arguments = CompletionsArguments;
+    type Response = CompletionsResponse;
+    const COMMAND: &'static str = "completions";
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionsArguments {
+    pub frame_id: Option<usize>,
+    pub text: String,
+    pub column: usize,
+    pub line: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionsResponse {
+    pub targets: Vec<CompletionItem>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionItem {
+    // TODO: do we need the other fields for our use case?
+    pub label: String,
 }
 
 pub struct SetVariableRequest {}

--- a/mos/src/debugger/types.rs
+++ b/mos/src/debugger/types.rs
@@ -770,7 +770,6 @@ pub struct CompletionsResponse {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CompletionItem {
-    // TODO: do we need the other fields for our use case?
     pub label: String,
 }
 

--- a/mos/src/lsp/traits.rs
+++ b/mos/src/lsp/traits.rs
@@ -30,7 +30,7 @@ pub trait NotificationHandler<N: Notification> {
 #[macro_export]
 macro_rules! impl_request_handler {
     ($ty:ty) => {
-        impl crate::lsp::traits::UntypedRequestHandler for $ty {
+        impl $crate::lsp::traits::UntypedRequestHandler for $ty {
             fn method(&self) -> &'static str {
                 RequestHandler::method(self)
             }
@@ -49,7 +49,7 @@ macro_rules! impl_request_handler {
 #[macro_export]
 macro_rules! impl_notification_handler {
     ($ty:ty) => {
-        impl crate::lsp::traits::UntypedNotificationHandler for $ty {
+        impl $crate::lsp::traits::UntypedNotificationHandler for $ty {
             fn method(&self) -> &'static str {
                 NotificationHandler::method(self)
             }

--- a/mos/src/main.rs
+++ b/mos/src/main.rs
@@ -25,7 +25,7 @@ mod test_runner;
 /// Miscellaneous utility methods
 mod utils;
 
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 /// mos - https://mos.datatra.sh
 pub struct Args {
     #[argh(subcommand)]
@@ -41,14 +41,14 @@ pub struct Args {
     error_style: ErrorStyle,
 }
 
-#[derive(PartialEq, Debug, strum::EnumString)]
+#[derive(PartialEq, Eq, Debug, strum::EnumString)]
 pub enum ErrorStyle {
     Short,
     Medium,
     Rich,
 }
 
-#[derive(argh::FromArgs, PartialEq, Debug)]
+#[derive(argh::FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand)]
 pub enum Subcommand {
     Init(InitArgs),

--- a/mos/src/memory_accessor.rs
+++ b/mos/src/memory_accessor.rs
@@ -38,14 +38,14 @@ pub fn ensure_ram_fn(
                 let len = if self.word { 2 } else { 1 };
                 let bytes = self.memory_accessor.lock().unwrap().read(a as u16, len);
                 if self.word {
-                    let lo = bytes.get(0);
+                    let lo = bytes.first();
                     let hi = bytes.get(1);
                     match (lo, hi) {
                         (Some(lo), Some(hi)) => Some(256 * (*hi as i64) + (*lo as i64)),
                         _ => None,
                     }
                 } else {
-                    bytes.get(0).map(|b| *b as i64)
+                    bytes.first().map(|b| *b as i64)
                 }
             });
             Ok(val.map(SymbolData::Number))

--- a/mos/src/test_runner/mod.rs
+++ b/mos/src/test_runner/mod.rs
@@ -56,7 +56,7 @@ impl PartialEq for TestFailure {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FormattedTrace(String);
 
 impl Display for FormattedTrace {


### PR DESCRIPTION
My attempt at #166.


Implements simple debugger completion with symbols, built-in stuff (cpu registers, cpu.flags, ram etc.). It's a little hard-coded, but that's because I didn't find a common place to unify the different things. I saw that the locals-view and other variable-views were a bit hardcoded as well (especially the flags). Hopefully this is okay 🙂 Unit tests, and have also done manual testing in Emacs, using [mos-mode](https://github.com/themkat/mos-mode) (my own creation to use mos in an easy way from Emacs). Everything works as expected (even completing when you have finished most of it, e.g, cpu.fla completes correctly to cpu.flags). Unsure if anything should be added, as the current completion solves all my needs. 