### PR TITLE
Add link to Emacs mos-mode in docs

### DIFF
--- a/docs/src/guide/ide/index.md
+++ b/docs/src/guide/ide/index.md
@@ -1,7 +1,7 @@
 # IDE support
 
-MOS provides a language server that can be used by IDEs to provide tooling.
+MOS provides a language server and debug adapter that can be used by IDEs to provide tooling.
 
-For now, this language server is used to provide a Visual Studio Code extension.
+It is used to provide a Visual Studio Code extension, and also [an Emacs package](https://github.com/themkat/mos-mode).
 
 ![Showing debugging in action](./mos-vscode.jpg)


### PR DESCRIPTION
Was very happy when @sagacity suggested that I add a link to Emacs mos-mode in my last PR, so here it is 🙂 Thought that the docs was the best place to put it, let me know if you disagree. 