### PR TITLE
Completion of mnemonics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "strum",
  "tempfile",
  "toml",
 ]

--- a/mos-core/Cargo.toml
+++ b/mos-core/Cargo.toml
@@ -29,6 +29,7 @@ petgraph = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smallvec = "1"
+strum = { version = "0.23", features = ["derive"] }
 toml = "0.5"
 
 [dev-dependencies]

--- a/mos-core/src/parser/mnemonic.rs
+++ b/mos-core/src/parser/mnemonic.rs
@@ -2,9 +2,11 @@ use super::{IResult, LocatedSpan};
 use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::map;
+use strum::{EnumIter, EnumString, EnumVariantNames};
 
 /// The available 6502 instructions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumVariantNames, EnumIter, EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum Mnemonic {
     Adc,
     And,


### PR DESCRIPTION
Fixes #196 

Like the title says, a simple autocomplete of mnemonics (aka assembly keywords). The implementation became very concise and simple with the help of strum, which made it possible to simply reuse the `Mnemonics` enum used during parsing 🙂 Tested with unit tests and manually in Emacs. 


Should be easy enough to extend to support other built-in keywords later.