### PR TITLE
Allow setting of registers when debugging

### DIFF
--- a/docs/src/guide/ide/index.md
+++ b/docs/src/guide/ide/index.md
@@ -2,6 +2,6 @@
 
 MOS provides a language server and debug adapter that can be used by IDEs to provide tooling.
 
-It is used to provide a Visual Studio Code extension, and also [an Emacs package](https://github.com/themkat/mos-mode).
+It is used to provide a Visual Studio Code extension, and also [an Emacs package](https://github.com/themkat/mos-mode). The Emacs package provides the same features as the Visual Studio Code extension, and you can refer to the VSCode documentation for details.
 
 ![Showing debugging in action](./mos-vscode.jpg)

--- a/docs/src/guide/ide/vscode.md
+++ b/docs/src/guide/ide/vscode.md
@@ -13,7 +13,7 @@ Once you have it installed, the following features will become available:
 * Automatic indentation
 * Show function documentation on hover
 
-The debugger supports breakpoints, local symbols, watches and evaluating expressions.
+The debugger supports breakpoints, local symbols, watches, setting variable values and evaluating expressions.
 
 ::: danger
 The debugger requires VICE 3.5+, which introduces the `-binarymonitor` command line argument.
@@ -80,6 +80,21 @@ You can also access a few extra symbols that allow you to access CPU registers a
 | cpu.flags.negative          | The N flag                                |
 | ram(...)                    | Read a byte from ram, e.g. `ram($d020)`   |
 | ram16(...)                  | Read a word from ram, e.g. `ram16($0314)` |
+
+## Set variable values during debugging
+::: danger
+Currently you are only able to set register values. Other types of variables will give an error!
+:::
+
+You can set the value of variables, either as decimal-, hexadecimal- or binary value. You specify the type or value with a prefix.
+
+| Prefix | Type        | Example   |
+|--------|-------------|-----------|
+| <none> | Decimal     | 123       |
+| $      | Hexadecimal | $d01      |
+| %      | Binary      | %00010010 |
+
+
 
 ## Options
 The following plugin options are available:

--- a/mos/src/commands/test.rs
+++ b/mos/src/commands/test.rs
@@ -28,16 +28,10 @@ pub fn test_command(args: &Args, root: &Path, cfg: &Config) -> MosResult<i32> {
     let mut test_cases = enumerate_test_cases(src.clone(), &input_path)?;
 
     if let Some(test_name) = &cfg.test.name {
-        test_cases = test_cases
-            .into_iter()
-            .filter(|(_, c)| &c.to_string() == test_name)
-            .collect();
+        test_cases.retain(|(_, c)| &c.to_string() == test_name);
     }
     if let Some(test_filter) = &cfg.test.filter {
-        test_cases = test_cases
-            .into_iter()
-            .filter(|(_, c)| c.to_string().contains(test_filter))
-            .collect();
+        test_cases.retain(|(_, c)| c.to_string().contains(test_filter));
     }
 
     let mut failed = vec![];

--- a/mos/src/debugger/adapters/mod.rs
+++ b/mos/src/debugger/adapters/mod.rs
@@ -117,7 +117,7 @@ pub trait MachineAdapter: MemoryAccessor {
 
     /// Sets a variable to a new value
     /// Note: Implementations currently only supports setting registers
-    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()>;
+    fn set_variable(&mut self, name: String, value: u8) -> MosResult<()>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/mos/src/debugger/adapters/mod.rs
+++ b/mos/src/debugger/adapters/mod.rs
@@ -114,6 +114,10 @@ pub trait MachineAdapter: MemoryAccessor {
 
     /// Get the cpu flags
     fn flags(&self) -> MosResult<u8>;
+
+    /// Sets a variable to a new value
+    /// Note: Implementations currently only supports setting registers
+    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()>;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/mos/src/debugger/adapters/test_runner/mod.rs
+++ b/mos/src/debugger/adapters/test_runner/mod.rs
@@ -295,6 +295,19 @@ impl MachineAdapter for TestRunnerAdapter {
     fn flags(&self) -> MosResult<u8> {
         Ok(self.runner.read().unwrap().cpu().get_status_register())
     }
+
+    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()> {
+        let mut write_runner = self.runner.write().unwrap();
+        let cpu_mut = write_runner.cpu_mut();
+        match name.as_str() {
+            "A" => cpu_mut.set_accumulator(value as u8),
+            "X" => cpu_mut.set_x_register(value as u8),
+            "Y" => cpu_mut.set_y_register(value as u8),
+            _ => {}
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/mos/src/debugger/adapters/test_runner/mod.rs
+++ b/mos/src/debugger/adapters/test_runner/mod.rs
@@ -296,13 +296,13 @@ impl MachineAdapter for TestRunnerAdapter {
         Ok(self.runner.read().unwrap().cpu().get_status_register())
     }
 
-    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()> {
+    fn set_variable(&mut self, name: String, value: u8) -> MosResult<()> {
         let mut write_runner = self.runner.write().unwrap();
         let cpu_mut = write_runner.cpu_mut();
         match name.as_str() {
-            "A" => cpu_mut.set_accumulator(value as u8),
-            "X" => cpu_mut.set_x_register(value as u8),
-            "Y" => cpu_mut.set_y_register(value as u8),
+            "A" => cpu_mut.set_accumulator(value),
+            "X" => cpu_mut.set_x_register(value),
+            "Y" => cpu_mut.set_y_register(value),
             _ => {}
         }
 

--- a/mos/src/debugger/adapters/vice/mod.rs
+++ b/mos/src/debugger/adapters/vice/mod.rs
@@ -241,6 +241,11 @@ impl MachineAdapter for ViceAdapter {
             self.send(ViceRequest::RegistersSet(*id, value as u8))?;
         }
 
+        // from VICE docs (https://vice-emu.sourceforge.io/vice_13.html#SEC312):
+        // "The transmission of any command causes the emulator to stop, similar to the regular monitor."
+        // so resume after setting the variable
+        self.resume()?;
+
         Ok(())
     }
 }

--- a/mos/src/debugger/adapters/vice/mod.rs
+++ b/mos/src/debugger/adapters/vice/mod.rs
@@ -230,7 +230,7 @@ impl MachineAdapter for ViceAdapter {
         }
     }
 
-    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()> {
+    fn set_variable(&mut self, name: String, value: u8) -> MosResult<()> {
         // check if variable is a register
         let register_id = self
             .available_registers
@@ -238,7 +238,7 @@ impl MachineAdapter for ViceAdapter {
             .find(|(_, reg_name)| reg_name.as_str() == name.as_str());
 
         if let Some((id, _)) = register_id {
-            self.send(ViceRequest::RegistersSet(*id, value as u8))?;
+            self.send(ViceRequest::RegistersSet(*id, value))?;
         }
 
         // from VICE docs (https://vice-emu.sourceforge.io/vice_13.html#SEC312):

--- a/mos/src/debugger/adapters/vice/mod.rs
+++ b/mos/src/debugger/adapters/vice/mod.rs
@@ -229,6 +229,10 @@ impl MachineAdapter for ViceAdapter {
             .into()),
         }
     }
+
+    fn set_variable(&mut self, name: String, value: i64) -> MosResult<()> {
+        todo!()
+    }
 }
 
 impl ViceAdapter {

--- a/mos/src/debugger/adapters/vice/mod.rs
+++ b/mos/src/debugger/adapters/vice/mod.rs
@@ -231,7 +231,17 @@ impl MachineAdapter for ViceAdapter {
     }
 
     fn set_variable(&mut self, name: String, value: i64) -> MosResult<()> {
-        todo!()
+        // check if variable is a register
+        let register_id = self
+            .available_registers
+            .iter()
+            .find(|(_, reg_name)| reg_name.as_str() == name.as_str());
+
+        if let Some((id, _)) = register_id {
+            self.send(ViceRequest::RegistersSet(*id, value as u8))?;
+        }
+
+        Ok(())
     }
 }
 

--- a/mos/src/debugger/adapters/vice/protocol.rs
+++ b/mos/src/debugger/adapters/vice/protocol.rs
@@ -54,6 +54,7 @@ pub enum ViceRequest {
     MemorySet(MemoryDescriptor, Vec<u8>),
     Ping,
     RegistersGet,
+    RegistersSet(u8, u8),
     RegistersAvailable,
     Quit,
 }
@@ -231,6 +232,15 @@ impl ViceRequest {
                 (0x15, body)
             }
             ViceRequest::RegistersGet => (0x31, vec![0]),
+            ViceRequest::RegistersSet(id, value) => {
+                let mut body = vec![];
+                body.write_u8(0)?;
+                body.write_u16::<LittleEndian>(1)?;
+                body.write_u8(16)?;
+                body.write_u8(*id)?;
+                body.write_u16::<LittleEndian>(*value as u16)?;
+                (0x32, body)
+            }
             ViceRequest::AdvanceInstructions(step_over_subroutines, instructions_to_skip) => {
                 let mut body = vec![];
                 body.write_u8(bool_to_u8(*step_over_subroutines))?;

--- a/mos/src/debugger/mod.rs
+++ b/mos/src/debugger/mod.rs
@@ -400,11 +400,11 @@ impl Handler<SetVariableRequest> for SetVariableRequestHandler {
             "A" | "X" | "Y" => {
                 // convert from assembly number representation to decimal
                 let assembly_number = args.value.trim();
-                let decimal_number = if assembly_number.starts_with("$") {
+                let decimal_number = if assembly_number.starts_with('$') {
                     // extra let seems to be needed to keep the compiler happy
                     let without_leading_char: String = assembly_number.chars().skip(1).collect();
                     u8::from_str_radix(&without_leading_char, 16)?
-                } else if assembly_number.starts_with("%") && assembly_number.len() == 9 {
+                } else if assembly_number.starts_with('%') && assembly_number.len() == 9 {
                     // extra let seems to be needed to keep the compiler happy
                     let without_leading_char: String = assembly_number.chars().skip(1).collect();
                     u8::from_str_radix(&without_leading_char, 2)?
@@ -412,8 +412,7 @@ impl Handler<SetVariableRequest> for SetVariableRequestHandler {
                     assembly_number.parse()?
                 };
 
-                let _result = conn
-                    .machine_adapter_mut()?
+                conn.machine_adapter_mut()?
                     .set_variable(args.name, decimal_number)?;
 
                 Ok(SetVariableResponse {

--- a/mos/src/debugger/mod.rs
+++ b/mos/src/debugger/mod.rs
@@ -392,10 +392,12 @@ impl Handler<SetVariableRequest> for SetVariableRequestHandler {
     fn handle(
         &self,
         conn: &mut DebugSession,
-        args: <SetVariableRequest as Request>::Arguments,
+        args: SetVariableArguments,
     ) -> MosResult<SetVariableResponse> {
-        match args.variables_reference {
-            1 => {
+        // TODO: the clients (Emacs, VSCode etc.) does not seem to send in variables_reference.
+        //       Would probably be a better way to separate different types of variables for later.
+        match args.name.as_str() {
+            "A" | "X" | "Y" => {
                 // convert from assembly number representation to decimal
                 let assembly_number = args.value.trim();
                 let decimal_number = if assembly_number.starts_with("$") {
@@ -422,7 +424,10 @@ impl Handler<SetVariableRequest> for SetVariableRequestHandler {
                     indexed_variables: None,
                 })
             }
-            _ => Err(anyhow::anyhow!("Incompatible variable assignment")),
+            _ => Err(anyhow::anyhow!(format!(
+                "Incompatible variable assignment, {}",
+                args.name
+            ))),
         }
     }
 }

--- a/mos/src/debugger/mod.rs
+++ b/mos/src/debugger/mod.rs
@@ -414,7 +414,7 @@ impl Handler<SetVariableRequest> for SetVariableRequestHandler {
 
                 let _result = conn
                     .machine_adapter_mut()?
-                    .set_variable(args.name, decimal_number as i64)?;
+                    .set_variable(args.name, decimal_number)?;
 
                 Ok(SetVariableResponse {
                     value: decimal_number.to_string(),

--- a/mos/src/test_runner/mod.rs
+++ b/mos/src/test_runner/mod.rs
@@ -214,6 +214,10 @@ impl TestRunner {
         &self.cpu
     }
 
+    pub fn cpu_mut(&mut self) -> &mut MOS6502 {
+        &mut self.cpu
+    }
+
     pub fn num_cycles(&self) -> usize {
         self.num_cycles
     }


### PR DESCRIPTION
Implements setVariable requests for the debugger, and support setting registers values (includes support for VICE [using register set operation](https://vice-emu.sourceforge.io/vice_13.html#SEC312)). Supports sending in decimals, hexadecimals and binary values (e.g, `128`, `$d0` and `%00001000` respectively). It should be easy enough to extend the support to other types of variables as well, but have kept that as future work to not make the PRs too large. There is also a minor challenge with name crashes (e.g, `X` as both a variable and a register name) that should be thought of before implementing regular variables. (simplest solution is simply to not allow those name crashes). One TODO addresses a future improvement that might help the implementation of general variable setting.

Fixes #110 

Unsure if/where this should be documented. Feel free to suggest something 🙂 