### PR TITLE
Remove version from release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Build archive
         shell: bash
         run: |
-          staging="mos-${{ env.RELEASE_VERSION }}-${{ matrix.target }}"
+          staging="mos-${{ matrix.target }}"
           mkdir -p "$staging"
 
           cp {CHANGELOG.md,LICENSE,README.md} "$staging/"


### PR DESCRIPTION
Why? The various clients, like mos-mode (Emacs) and the VSCode client, can automatically download mos by need. With the current approach, we have to code in the version they should download in the filename. If we omit the version in the release archives, we can have static download URLs for the latest version: `https://github.com/datatrash/mos/releases/latest/download/mos-x86_64-apple-darwin.tar.gz` 

This makes it easier for the clients to download mos by need without the user having to do as much. Already implemented in mos-mode:
https://github.com/themkat/mos-mode/pull/8
(though hardcoded for a version, which can be avoided if they are not in the filename)